### PR TITLE
Revert fix for noflo/noflo-ui#352

### DIFF
--- a/elements/noflo-context.html
+++ b/elements/noflo-context.html
@@ -125,9 +125,7 @@
               if (typeof ga === 'function') {
                 ga('send', 'event', 'menu', 'click', 'openNode');
               }
-              // Work around Firefox location.hash getter bug #352
-              var hash = window.location.href.split('#')[1] || '';
-              window.location.hash = hash + '/' + encodeURIComponent(item.id);
+              window.location.hash += '/' + encodeURIComponent(item.id);
             }
           };
           for (menuKey in defaultMenu) {


### PR DESCRIPTION
Firefox 41 fixed the issue in 2015 and the hack was causing Fortify Software to get confused. Once this fix is verified. An upstream PR should be created for noflo/noflo-ui.
